### PR TITLE
wsl.conf added

### DIFF
--- a/linux_files/wsl.conf
+++ b/linux_files/wsl.conf
@@ -1,0 +1,8 @@
+[automount]
+enabled = true
+options = "metadata,uid=1000,gid=1000,umask=22,fmask=11,case=off"
+mountFsTab = true
+
+[network]
+generateHosts = true
+generateResolvConf = true


### PR DESCRIPTION
by adding the file `wsl.conf`, the flag metadata will be set from the first mount, avoiding some issues later on with the Windows filesystem.
this file will be referenced in the script to create root.gz