### PR TITLE
Address build-essential breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WLinux can be downloaded from the [Microsoft Store](https://afflnk.microsoft.com
 
 - A fast Linux terminal and development environment for developers and pro-users built on [Windows® Subsystem for Linux](https://github.com/sirredbeard/Awesome-WSL) (WSL) on Windows 10.
 - Out-of-the-box support for most Linux graphical apps with no need to configure display or libGL settings. Note: Requires a Windows-based X client, such as [X410](http://afflnk.microsoft.com/c/1291904/459838/7593?prodsku=9NLP712ZMN9Q&u=https%3A%2F%2Fwww.microsoft.com%2Fen-us%2Fstore%2Fp%2Fx410%2F9NLP712ZMN9Q).
-- Popular development tools, including zsh shell, git, neovim, and python 3.7 pre-installed. Additional packages can be easily installed via the apt package management system (e.g. `$ sudo apt install nodejs`) from the [expansive Debian repos](https://packages.debian.org/stable/) and third-party Debian-compatible repos. The Debian backports and testing repos are also pre-configured.
+- Popular development tools, including zsh shell, git, neovim, and python pre-installed. Additional packages can be easily installed via the apt package management system (e.g. `$ sudo apt install nodejs`) from the [expansive Debian repos](https://packages.debian.org/stable/) and third-party Debian-compatible repos. The Debian backports and testing repos are also pre-configured.
 - Pre-installed with [wslu](https://github.com/wslutilities/wslu), a set of useful open-source utilities for interacting between WSL and Windows 10.
 - A handful of unnecessary packages, such as systemd, have been removed to improve stability and security.
 - Additional scripts to easily install the following popular applications:

--- a/create-targz-x64.sh
+++ b/create-targz-x64.sh
@@ -46,7 +46,7 @@ sudo chroot $DIST chmod u+x /opt/installcode.sh
 
 # install python 3.7 from testing
 sudo chroot $DIST apt update
-sudo chroot $DIST apt -t testing install python3.7 -y
+#sudo chroot $DIST apt -t testing install python3.7 -y
 
 # set up the latest wslu app and n npm management tool
 sudo chroot $DIST chmod 644 /etc/apt/trusted.gpg.d/wslu.gpg


### PR DESCRIPTION
This addresses the issue in #48.

Pulling in python 3.7 from testing in 1.1.16 also brings in build-essential from testing, which breaks updates to build-essential unless -t testing is specified.

This fix downgrades default python to 3.5 from stretch just for 1.1.17, the maintenance release before 1.1.20 with the new onboarding which will address this issue architecturally.

Users can still upgrade to python 3.7 with apt -t testing install python3.7.

It is a minor but temporary regression. So far the only one and we have a workaround and plan to solve it in 1.1.20.