### PR TITLE
Bring in build-essential from testing too to address mismatch

### DIFF
--- a/create-targz-x64.sh
+++ b/create-targz-x64.sh
@@ -46,7 +46,7 @@ sudo chroot $DIST chmod u+x /opt/installcode.sh
 
 # install python 3.7 from testing
 sudo chroot $DIST apt update
-sudo chroot $DIST apt -t testing install python3.7 -y
+sudo chroot $DIST apt -t testing install python3.7 build-essential -y
 
 # set up the latest wslu app and n npm management tool
 sudo chroot $DIST chmod 644 /etc/apt/trusted.gpg.d/wslu.gpg


### PR DESCRIPTION
I changed my mind about the regression solution in #49.

The solution, while we are still shipping python as a pre-installed feature (pre-OOBE) is to bring in build-essential from testing to address the discrepancy.

This is still temporary workaround until OOBE.