### PR TITLE
Rebase to Debian testing (currently buster)

### DIFF
--- a/create-targz-x64.sh
+++ b/create-targz-x64.sh
@@ -9,7 +9,7 @@ set -e
 BUILDIR=$(pwd)
 TMPDIR=$(mktemp -d)
 ARCH="amd64"
-DIST="stable"
+DIST="testing"
 cd $TMPDIR
 
 # bootstrap image
@@ -73,4 +73,3 @@ cd $TMPDIR
 cp install.tar.gz $BUILDIR/x64/
 cd $BUILDIR
 
-# cp install.tar.gz /mnt/c/Users/Hayden/OneDrive/Documents/GitHub/WLinux/x64/

--- a/linux_files/sources.list
+++ b/linux_files/sources.list
@@ -1,16 +1,16 @@
-deb https://deb.debian.org/debian stable main
-# deb-src https://deb.debian.org/debian stable main
+deb https://deb.debian.org/debian testing main
+# deb-src https://deb.debian.org/debian testing main
 
-deb https://deb.debian.org/debian stable-updates main
-# deb-src https://deb.debian.org/debian stable-updates main
+deb https://deb.debian.org/debian testing-updates main
+# deb-src https://deb.debian.org/debian testing-updates main
 
-deb http://security.debian.org/debian-security/ stable/updates main
-# deb-src http://security.debian.org/debian-security/ stable/updates main
+deb http://security.debian.org/debian-security/ testing/updates main
+# deb-src http://security.debian.org/debian-security/ testing/updates main
 
-deb https://deb.debian.org/debian stretch-backports main
+# deb https://deb.debian.org/debian stretch-backports main
 # deb-src https://deb.debian.org/debian stretch-backports main
 
-deb https://deb.debian.org/debian testing main
+# deb https://deb.debian.org/debian testing main
 # deb-src https://deb.debian.org/debian testing main
 
 deb https://apt.patrickwu.ml/ stable main


### PR DESCRIPTION
I have been testing this for quite some time and had no issues. I saw some complaints about the age of the packages in stretch. Rather than continue trying to mesh stable and testing, which caused the build-essential bug, why not just move to testing? Most of the packages in testing have been tested on WSL in the Ubuntu 18.04 WSL distro.