### PR TITLE
Patch: Add symlink from new-->old drive mount point in dockerinstall()

### DIFF
--- a/linux_files/setup
+++ b/linux_files/setup
@@ -891,6 +891,10 @@ if (whiptail --title "DOCKER" --yesno "Would you like to install the bridge to D
             else
                 sudo sed -i 's$\(root=\)\(.*\)$\1/$' /etc/wsl.conf
             fi
+
+	    # Temporary fix until WSLU fixes their path tool not updating when mount changed
+	    sudo rm -r /mnt/c
+	    sudo ln -s /c /mnt/c
         fi
     fi
 


### PR DESCRIPTION
By adding a symbolic link from the new-->old drive mount point
this allows cassandrainstall to continue to work while the WSLU
tool in its current state doesn't return the updated path.

Signed-off-by: Kim Bradley <kim.jamie.bradley@gmail.com>