### PR TITLE
Fix: Open With WLinux in Context Menu leads to error #195

### DIFF
--- a/linux_files/setup
+++ b/linux_files/setup
@@ -707,7 +707,7 @@ fi
 }
 
 function explorerintegration {
-if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explorer shell integration?" 8 65) then
+if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explorer shell integration?" 8 65); then
     echo "Enabling Windows Explorer shell integration."
     createtmp
     cat << 'EOF' >> Install.reg
@@ -715,12 +715,14 @@ if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explor
     [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\WLinux]
     @="Open with WLinux"
     [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\WLinux\command]
-    @="wlinux.exe run \"cd \\\"$(wslpath \\\"%V\\\")\\\" && $(getent passwd $LOGNAME | cut -d: -f7)\""
+    @="_wlinuxPath_ run \"cd \\\"$(wslpath \\\"%V\\\")\\\" && $(getent passwd $LOGNAME | cut -d: -f7)\""
     [HKEY_CURRENT_USER\Software\Classes\Directory\shell\WLinux]
     @="Open with WLinux"
     [HKEY_CURRENT_USER\Software\Classes\Directory\shell\WLinux\command]
-    @="wlinux.exe run \"cd \\\"$(wslpath \\\"%V\\\")\\\" && $(getent passwd $LOGNAME | cut -d: -f7)\""
+    @="_wlinuxPath_ run \"cd \\\"$(wslpath \\\"%V\\\")\\\" && $(getent passwd $LOGNAME | cut -d: -f7)\""
 EOF
+    wlinuxPath=$(wslpath -m "$(whereis wlinux.exe | cut --delimiter=' ' -f2)" | sed 's$/$\\\\\\\\$g')
+    sed -i "s/_wlinuxPath_/${wlinuxPath}/g" Install.reg
     cp Install.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Install.reg
     cmd.exe /C "Reg import %TEMP%\Install.reg"
     cleantmp


### PR DESCRIPTION
There are installations where wlinux.exe cannot be found by explorer (usually when the user have more than one distribution installed) and right click Open with WLinux won't find wlinux.exe. The fix is to specify the complete path in the registry key.