### PR TITLE
Catch if Docker for Windows is not installed

### DIFF
--- a/linux_files/setup
+++ b/linux_files/setup
@@ -842,14 +842,14 @@ function dockerinstall {
 if (whiptail --title "DOCKER" --yesno "Would you like to install the bridge to Docker?" 8 55); then
     echo "Installing the bridge to Docker."
 
-    connected=$(docker.exe version 2>&1 | grep -c "docker daemon is not running.")
+    connected=$(docker.exe version 2>&1 | grep -c "docker daemon is not running.\|docker.exe: command not found")
     while [[ ${connected} != 0  ]]; do
-        if ! (whiptail --title "DOCKER" --yesno "Docker for Windows appears not to be running, please check it and ensure that it is running correctly. Would you like to try again?" 9 75); then
+        if ! (whiptail --title "DOCKER" --yesno "Docker Desktop appears not to be running, please check it and ensure that it is running correctly. Would you like to try again?" 9 75); then
             return
 
         fi
 
-        connected=$(docker.exe version 2>&1 | grep -c "docker daemon is not running.")
+        connected=$(docker.exe version 2>&1 | grep -c "docker daemon is not running.\|docker.exe: command not found")
 
     done
 


### PR DESCRIPTION
Adding the case that the user attempts to install the bridge without first install Docker Desktop. I suspect that this is the issue with #243