### PR TITLE
Update setup to correct uninstall of shell integration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,7 +78,6 @@ Status: Released.
 
 Status: Early December. Testing.
 
-- Initial ARM64 support.
 - Apache Cassandra inclusion.
 - Latest Debian build.
 - Minor fixes and improvements.
@@ -87,6 +86,7 @@ Status: Early December. Testing.
 
 Status: Mid December.
 
+- Initial ARM64 support.
 - Minor fixes and improvements.
 
 See https://github.com/WhitewaterFoundry/WLinux/pulls for features under testing/active developmment.

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -732,7 +732,7 @@ EOF
     [-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\WLinux]
     [-HKEY_CURRENT_USER\Software\Classes\Directory\shell\WLinux]
 EOF
-    cp Install.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Uninstall.reg
+    cp Uninstall.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Uninstall.reg
     cmd.exe /C "Reg import %TEMP%\Uninstall.reg"
     cleantmp
 fi


### PR DESCRIPTION
Fix uninstall of shell integration

See Issue #252