### PR TITLE
Fix zsh install --> adds source /etc/profile to zshrc

### DIFF
--- a/linux_files/setup
+++ b/linux_files/setup
@@ -259,15 +259,15 @@ for i in ${!options[@]}; do
 
         # Backup old zshrc if existent (e.g. wlinux-setup being re-run)
         if [ ! -d "/etc/zsh/zshrc" ] ; then
-                echo "Old zshrc found. Backing up and replacing"
-                sudo mv /etc/zsh/zshrc /etc/zsh/zshrc.old
+                echo "Old zshrc found. Backing up"
+                sudo cp /etc/zsh/zshrc /etc/zsh/zshrc.old
         fi
       
         # Need to "unsetopt no_match" to stop line31 in /etc/profile failing on not finding anything under /etc/profile.d/*
         # Reset after to prevent any unforeseen consequences
         # ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more similarly to zsh (we're currently doing reverse)
         # This might help if other alternative shells run into same issue
-        sudo touch /etc/zsh/zshrc
+	echo "" | sudo tee -a /etc/zsh/zshrc
         echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
         echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
         echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -263,17 +263,23 @@ for i in ${!options[@]}; do
         if [ -f "/etc/zsh/zshrc" ] ; then
                 if [ -f "/etc/zsh/"$ZSH_SETUP ] ; then
                         echo "wlinux-setup has already modified zshrc"
-                        echo "run 'sudo rm /etc/zsh/" $ZSH_INSTALLED " && wlinux-setup' to re-create config file"
+                        echo "run 'sudo rm /etc/zsh/$ZSH_INSTALLED && wlinux-setup' to re-create config file"
                 else
                         echo "Old zshrc found & not edited before --> backing up"
-                        sudo cp /etc/zsh/zshrc /etc/zsh/zshrc.old
+                        
+                        # Get current date-time
+                        dt=$(date '+%d/%m/%Y %H:%M:%S')
+                        # Save backup with date-time
+                        sudo cp /etc/zsh/zshrc /etc/zsh/zshrc_$dt.old
+                        # Delete old  zshrc so we can start fresh
+                        sudo rm /etc/zsh/zshrc
 
                         # Need to "unsetopt no_match" to stop line31 in /etc/profile failing on not finding anything under /etc/profile.d/*
                         # Reset after to prevent any unforeseen consequences.
                         # ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more like zsh (we're currently doing reverse)
                         # This would prevent issues in other shell alternatives if they appear.
-                        echo "Modifying zshrc to source /etc/profile"
-                        echo "" | sudo tee -a /etc/zsh/zshrc
+                        echo "Creating fresh zshrc and modifying to source /etc/profile"
+                        sudo touch /etc/zsh/zshrc
                         echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
                         echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
                         echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -268,7 +268,7 @@ for i in ${!options[@]}; do
                         echo "Old zshrc found & not edited before --> backing up"
                         
                         # Get current date-time
-                        dt=$(date '+%d/%m/%Y %H:%M:%S')
+                        dt=$(date '+%d%m%Y-%H%M')
                         # Save backup with date-time
                         sudo cp /etc/zsh/zshrc /etc/zsh/zshrc_$dt.old
                         # Delete old  zshrc so we can start fresh

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -254,34 +254,34 @@ for i in ${!options[@]}; do
         echo "Installing ${options[i]}..."
         sudo apt install ${options[i]} -y	
 	
-	if [ ${options[i]} = "zsh" ]
-	then
+        if [ ${options[i]} = "zsh" ]
+        then
 
-	# Backup old zshrc if existent (e.g. wlinux-setup being re-run)
-	if [ ! -d "/etc/zsh/zshrc" ] ; then
-		echo "Old zshrc found. Backing up and replacing"
-		sudo mv /etc/zsh/zshrc /etc/zsh/zshrc.old
-	fi
+        # Backup old zshrc if existent (e.g. wlinux-setup being re-run)
+        if [ ! -d "/etc/zsh/zshrc" ] ; then
+                echo "Old zshrc found. Backing up and replacing"
+                sudo mv /etc/zsh/zshrc /etc/zsh/zshrc.old
+        fi
       
         # Need to "unsetopt no_match" to stop line31 in /etc/profile failing on not finding anything under /etc/profile.d/*
-	# Reset after to prevent any unforeseen consequences
-	# ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more similarly to zsh (we're currently doing reverse)
-	# This might help if other alternative shells run into same issue
-	sudo touch /etc/zsh/zshrc
-	echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
-	echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
-	echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc
+        # Reset after to prevent any unforeseen consequences
+        # ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more similarly to zsh (we're currently doing reverse)
+        # This might help if other alternative shells run into same issue
+        sudo touch /etc/zsh/zshrc
+        echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
+        echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
+        echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc
       
         if (whiptail --title "zsh" --yesno "Would you like to download and install oh-my-zsh? This is a framework for managing your zsh installation" 8 95) then
             createtmp
-            whiptail --title "zsh" --msgbox "After oh my zsh is installed and launched, type 'exit' and ENTER to return to wlinux-setup" 8 95
+            whiptail --title "zsh" --msgbox "After oh-my-zsh is installed and launched, type 'exit' and ENTER to return to wlinux-setup" 8 95
             mkdir "Type exit to return to wlinux-setup" 
             cd "Type exit to return to wlinux-setup" 
-	        sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-	        cd ..
+	    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+	    cd ..
             cleantmp
         else
-            echo "Skipping Oh My Zsh"
+            echo "Skipping oh-my-zsh"
         fi
 	fi
 	
@@ -289,10 +289,10 @@ for i in ${!options[@]}; do
 	then
         if (whiptail --title "fish" --yesno "Would you like to download and install oh-my-fish?" 8 55) then
             createtmp
-	        whiptail --title "fish" --msgbox "After oh my fish is installed and launched, type 'exit' and ENTER to return to wlinux-setup" 8 95
+	    whiptail --title "fish" --msgbox "After oh my fish is installed and launched, type 'exit' and ENTER to return to wlinux-setup" 8 95
             mkdir "Type exit to return to wlinux-setup" 
             cd "Type exit to return to wlinux-setup" 
-	        curl -L https://get.oh-my.fish | fish
+	    curl -L https://get.oh-my.fish | fish
             cd ..
             cleantmp
         else

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -268,7 +268,7 @@ EOF
         sudo cp zshrc /etc/zsh/zshrc
         cleantmp
       
-        if (whiptail --title "zsh" --yesno "Would you like to download and install oh-my-zsh?" 8 55) then
+        if (whiptail --title "zsh" --yesno "Would you like to download and install oh-my-zsh? This is a framework for managing your zsh installation" 8 95) then
             createtmp
             whiptail --title "zsh" --msgbox "After oh my zsh is installed and launched, type 'exit' and ENTER to return to wlinux-setup" 8 95
             mkdir "Type exit to return to wlinux-setup" 

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -263,16 +263,14 @@ for i in ${!options[@]}; do
 		sudo mv /etc/zsh/zshrc /etc/zsh/zshrc.old
 	fi
       
-        createtmp  
-        at << 'EOF' >> zshrc
-export DISPLAY=:0
-export LIBGL_ALWAYS_INDIRECT=1
-export NO_AT_BRIDGE=1
-alias wlinux-setup='bash /etc/setup'
-alias wlinux-help='bash /etc/helpme'
-EOF
-        sudo cp zshrc /etc/zsh/zshrc
-        cleantmp
+        # Need to "unsetopt no_match" to stop line31 in /etc/profile failing on not finding anything under /etc/profile.d/*
+	# Reset after to prevent any unforeseen consequences
+	# ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more similarly to zsh (we're currently doing reverse)
+	# This might help if other alternative shells run into same issue
+	sudo touch /etc/zsh/zshrc
+	echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
+	echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
+	echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc
       
         if (whiptail --title "zsh" --yesno "Would you like to download and install oh-my-zsh? This is a framework for managing your zsh installation" 8 95) then
             createtmp

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -252,26 +252,37 @@ for i in ${!options[@]}; do
     then
         toselect+=("${options[i]}")
         echo "Installing ${options[i]}..."
-        sudo apt install ${options[i]} -y	
-	
+        sudo apt install ${options[i]} -y
+
         if [ ${options[i]} = "zsh" ]
         then
 
+        ZSH_SETUP=".zsh_wlinux"
+
         # Backup old zshrc if existent (e.g. wlinux-setup being re-run)
-        if [ ! -d "/etc/zsh/zshrc" ] ; then
-                echo "Old zshrc found. Backing up"
-                sudo cp /etc/zsh/zshrc /etc/zsh/zshrc.old
+        if [ -f "/etc/zsh/zshrc" ] ; then
+                if [ -f "/etc/zsh/"$ZSH_SETUP ] ; then
+                        echo "wlinux-setup has already modified zshrc"
+                        echo "run 'sudo rm /etc/zsh/" $ZSH_INSTALLED " && wlinux-setup' to re-create config file"
+                else
+                        echo "Old zshrc found & not edited before --> backing up"
+                        sudo cp /etc/zsh/zshrc /etc/zsh/zshrc.old
+
+                        # Need to "unsetopt no_match" to stop line31 in /etc/profile failing on not finding anything under /etc/profile.d/*
+                        # Reset after to prevent any unforeseen consequences.
+                        # ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more like zsh (we're currently doing reverse)
+                        # This would prevent issues in other shell alternatives if they appear.
+                        echo "Modifying zshrc to source /etc/profile"
+                        echo "" | sudo tee -a /etc/zsh/zshrc
+                        echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
+                        echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
+                        echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc
+
+                        # Create .zsh_wlinux file to let future runs know zshrc has been modified by wlinux-setup
+                        sudo touch /etc/zsh/$ZSH_SETUP
+                fi
         fi
-      
-        # Need to "unsetopt no_match" to stop line31 in /etc/profile failing on not finding anything under /etc/profile.d/*
-        # Reset after to prevent any unforeseen consequences
-        # ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more similarly to zsh (we're currently doing reverse)
-        # This might help if other alternative shells run into same issue
-	echo "" | sudo tee -a /etc/zsh/zshrc
-        echo "unsetopt no_match" | sudo tee -a /etc/zsh/zshrc
-        echo "source /etc/profile" | sudo tee -a /etc/zsh/zshrc
-        echo "setopt no_match" | sudo tee -a /etc/zsh/zshrc
-      
+
         if (whiptail --title "zsh" --yesno "Would you like to download and install oh-my-zsh? This is a framework for managing your zsh installation" 8 95) then
             createtmp
             whiptail --title "zsh" --msgbox "After oh-my-zsh is installed and launched, type 'exit' and ENTER to return to wlinux-setup" 8 95

--- a/linux_files/setup
+++ b/linux_files/setup
@@ -256,6 +256,12 @@ for i in ${!options[@]}; do
 	
 	if [ ${options[i]} = "zsh" ]
 	then
+
+	# Backup old zshrc if existent (e.g. wlinux-setup being re-run)
+	if [ ! -d "/etc/zsh/zshrc" ] ; then
+		echo "Old zshrc found. Backing up and replacing"
+		sudo mv /etc/zsh/zshrc /etc/zsh/zshrc.old
+	fi
       
         createtmp  
         at << 'EOF' >> zshrc


### PR DESCRIPTION
Sources /etc/profile in zshrc, and adds a flag-file to /etc/zsh to stop repeated runnings of wlinux-setup causing repeated appendings to zshrc. Have run through a few builds and run into no issues. could do with others to confirm.