### PR TITLE
Update DistroLauncher-Appx.vcxproj

### DIFF
--- a/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -82,7 +82,7 @@
     <AppxBundlePlatforms>x64|arm64</AppxBundlePlatforms>
     <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
-    <AppxPackageDir>C:\Users\Hayden\OneDrive\Desktop\</AppxPackageDir>
+    <AppxPackageDir>$(SolutionDir)\out\</AppxPackageDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>


### PR DESCRIPTION
This changes the build output to the out folder. I feel like this would be easier to find than creating a new user directory. What's your opinion?